### PR TITLE
feat : 객체 선택 후 저장 시 선택 해제

### DIFF
--- a/lib/blocs/custom/custom_bloc.dart
+++ b/lib/blocs/custom/custom_bloc.dart
@@ -225,26 +225,30 @@ class CustomBloc extends Bloc<CustomEvent, CustomState> {
     CaptureAndSaveEvent event,
     Emitter<CustomState> emit,
   ) async {
-    if (event.globalKey.currentContext != null) {
-      final RenderRepaintBoundary boundary = event.globalKey.currentContext!
-          .findRenderObject() as RenderRepaintBoundary;
+    state.controller.doneAllBorders();
 
-      final image = await boundary.toImage();
-      final byteData = await image.toByteData(format: ImageByteFormat.png);
-      final pngBytes = byteData?.buffer.asUint8List();
+    Future.delayed(const Duration(milliseconds: 200)).then((_) async {
+      if (event.globalKey.currentContext != null) {
+        final RenderRepaintBoundary boundary = event.globalKey.currentContext!
+            .findRenderObject() as RenderRepaintBoundary;
 
-      if (pngBytes != null) {
-        final result = await ImageGallerySaver.saveImage(
-            Uint8List.fromList(pngBytes),
-            quality: 100);
-        if (result != null && result.isNotEmpty) {
-          Utils.showSnackBar(event.globalKey.currentContext!, '이미지가 저장되었습니다');
-          return;
+        final image = await boundary.toImage();
+        final byteData = await image.toByteData(format: ImageByteFormat.png);
+        final pngBytes = byteData?.buffer.asUint8List();
+
+        if (pngBytes != null) {
+          final result = await ImageGallerySaver.saveImage(
+              Uint8List.fromList(pngBytes),
+              quality: 100);
+          if (result != null && result.isNotEmpty) {
+            Utils.showSnackBar(event.globalKey.currentContext!, '이미지가 저장되었습니다');
+            return;
+          }
         }
+        Utils.showSnackBar(event.globalKey.currentContext!, '이미지을 실패하였습니다');
       }
-      Utils.showSnackBar(event.globalKey.currentContext!, '이미지을 실패하였습니다');
-    }
 
-    emit(state.copyWith());
+      emit(state.copyWith());
+    });
   }
 }


### PR DESCRIPTION
객체 선택한 상태에서 저장 진행 시 선택 상태로 저장되던 부분을 해지 후 저장하도록 개선 진행하였습니다.

<br/>
<br/>

**라이브러리 측 커스텀 작업이 필요하여 하단 작업들이 추가로 진행되었으니 추가 적용 부탁드려요~!**
파일의 경우 Find in File > Scope > All Place로 설정해주시면 확인 가능합니다

<br/>

**LindiController 파일**
하단 함수 추가


```

  // 모든 선택 border 안 보이도록 한다.
  doneAllBorders(){
    widgets.forEach((element) {
      element.update(false);
    });

    notifyListeners();
  }

```


<br/>

**DraggableWidget 파일**
하단  변수 Privete -> Public


```

  /// Internal state [showBorder].
  ///
  /// Defaults to true
  ///
  bool showBorder = true;

```
